### PR TITLE
.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,6 +22,16 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+    flavorDimensions "version"
+    productFlavors {
+        stephanElectronics {
+            applicationId "ch.stephanelectronics.mooltifill"
+            versionNameSuffix "-se"
+        }
+        mathfactory {
+
+        }
+    }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,7 @@ android {
     flavorDimensions "version"
     productFlavors {
         stephanElectronics {
-            applicationId "ch.stephanelectronics.mooltifill"
+            applicationId "de.mathfactory.mooltifill"
             versionNameSuffix "-se"
         }
         mathfactory {

--- a/app/src/main/java/de/mathfactory/mooltifill/AwarenessService.kt
+++ b/app/src/main/java/de/mathfactory/mooltifill/AwarenessService.kt
@@ -106,7 +106,7 @@ class AwarenessService : Service() {
         }
 
         suspend fun mooltipassDevice(context: Context): MooltipassDevice? {
-            if(device == null) {
+            if(device == null || device?.isDisconnected() != false) {
                 device = MooltipassDevice.connect(context, AwarenessCallback(context))
             }
             return device

--- a/app/src/main/java/de/mathfactory/mooltifill/AwarenessService.kt
+++ b/app/src/main/java/de/mathfactory/mooltifill/AwarenessService.kt
@@ -20,7 +20,6 @@ class AwarenessCallback(private val context: Context) : BluetoothGattCallback() 
     private var mConnectState: Int = BluetoothProfile.STATE_DISCONNECTED
 
     private fun sendNotification() {
-        if(!SettingsActivity.isAwarenessEnabled(context)) return
         val msg = when (mConnectState) {
             BluetoothProfile.STATE_CONNECTED -> "Connected"
             BluetoothProfile.STATE_DISCONNECTED -> "Disconnected"
@@ -67,6 +66,7 @@ class AwarenessCallback(private val context: Context) : BluetoothGattCallback() 
 class AwarenessService : Service() {
     companion object {
         internal fun CoroutineScope.notify(context: Context, msg: String) = launch {
+            if(!SettingsActivity.isAwarenessEnabled(context)) return@launch
             serviceStarted.await()
             if(SettingsActivity.isDebugEnabled(context)) {
                 Log.d("Mooltifill", "Aware: $msg")
@@ -147,7 +147,6 @@ class AwarenessService : Service() {
 
     private val baReceiver = object :BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
-            if(!SettingsActivity.isAwarenessEnabled(context)) return
             val msg = when(intent.action) {
                 BluetoothAdapter.ACTION_STATE_CHANGED -> {
                     when(intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, -1)) {

--- a/app/src/main/java/de/mathfactory/mooltifill/MooltipassDevice.kt
+++ b/app/src/main/java/de/mathfactory/mooltifill/MooltipassDevice.kt
@@ -60,17 +60,18 @@ private class MooltipassGatt(val gatt: BluetoothGatt) {
 
 @ExperimentalCoroutinesApi
 class MooltipassDevice(private val device: BluetoothDevice, private var debug: Boolean) {
+    private var mIsDisconnected: Boolean = false
     private var mLocked: Boolean? = null
     private var mpGatt = CompletableDeferred<MooltipassGatt>()
 
     suspend fun hasCommService(): Boolean = mpGatt.await().service() != null
-
 
     private suspend fun waitBusy() {
         commFlow.first { !it.busy }
     }
 
     suspend fun readNotified(): ByteArray? {
+        if(mIsDisconnected) Log.e("Mooltifill", "readNotified() with mIsDisconnected == true")
         return withTimeoutOrNull(READ_TIMEOUT) {
             val r = (commFlow.firstOrNull { it is CommOp.ChangedChar } as CommOp.ChangedChar).value
             commFlow.value = CommOp.Idle()
@@ -79,6 +80,7 @@ class MooltipassDevice(private val device: BluetoothDevice, private var debug: B
     }
 
     suspend fun readGatt(): ByteArray? {
+        if(mIsDisconnected) Log.e("Mooltifill", "readGatt() with mIsDisconnected == true")
         waitBusy()
         val mp = mpGatt.await()
         mp.readCharacteristic()?.let { c ->
@@ -92,6 +94,7 @@ class MooltipassDevice(private val device: BluetoothDevice, private var debug: B
     }
 
     suspend fun flushRead(): ByteArray? {
+        if(mIsDisconnected) Log.e("Mooltifill", "flushRead() with mIsDisconnected == true")
         var pp:ByteArray? = null
         var p = readGatt()
         while (!p.contentEquals(pp)) {
@@ -111,6 +114,7 @@ class MooltipassDevice(private val device: BluetoothDevice, private var debug: B
     }
 
     suspend fun send(pkt: ByteArray): Int? {
+        if(mIsDisconnected) Log.e("Mooltifill", "send() with mIsDisconnected == true")
         waitBusy()
         val mp = mpGatt.await()
         mp.writeCharacteristic()?.let { c ->
@@ -131,6 +135,7 @@ class MooltipassDevice(private val device: BluetoothDevice, private var debug: B
     }
 
     suspend fun readMessage(): Array<ByteArray>? {
+        if(mIsDisconnected) Log.e("Mooltifill", "readMessage() with mIsDisconnected == true")
         val pkt = readNotified() ?: return null
         val nPkts = (pkt[1].toUByte().toInt() % 16) + 1
         val id = pkt[1].toUByte().toInt() shr 4
@@ -286,8 +291,13 @@ class MooltipassDevice(private val device: BluetoothDevice, private var debug: B
                     bleCallback?.onServicesDiscovered(gatt, status)
                 }
             }
+            mIsDisconnected = false
             val gatt = device.connectGatt(context, false, cb, BluetoothDevice.TRANSPORT_LE)
             awaitClose {
+                if(debug) {
+                    Log.d("Mooltifill", "awaitClose")
+                }
+                mIsDisconnected = true
                 gatt.disconnect()
             }
         }.collect {
@@ -299,7 +309,11 @@ class MooltipassDevice(private val device: BluetoothDevice, private var debug: B
     }
 
     suspend fun disconnect() {
+        if(debug) {
+            Log.d("Mooltifill", "disconnect()")
+        }
         mpGatt.await().gatt.disconnect()
+        mIsDisconnected = true
     }
 
     fun setDebug(debug: Boolean) {
@@ -309,6 +323,8 @@ class MooltipassDevice(private val device: BluetoothDevice, private var debug: B
     fun isLocked(): Boolean? {
         return mLocked
     }
+
+    fun isDisconnected(): Boolean = mIsDisconnected
 
     @FlowPreview
     companion object {

--- a/app/src/main/java/de/mathfactory/mooltifill/MooltipassDevice.kt
+++ b/app/src/main/java/de/mathfactory/mooltifill/MooltipassDevice.kt
@@ -346,7 +346,7 @@ class MooltipassScan {
 
     private fun pairedDevice(context: Context): BluetoothDevice? {
         val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
-        return bluetoothManager.adapter.bondedDevices.firstOrNull(::filter)
+        return bluetoothManager.adapter.bondedDevices.lastOrNull(::filter)
     }
 
     fun deviceFlow(context: Context): Flow<BluetoothDevice> {

--- a/app/src/main/java/de/mathfactory/mooltifill/SettingsActivity.kt
+++ b/app/src/main/java/de/mathfactory/mooltifill/SettingsActivity.kt
@@ -163,12 +163,7 @@ class SettingsActivity : AppCompatActivity() {
                     val ping = withContext(Dispatchers.IO) {
                         MooltifillActivity.ping(requireContext())
                     }
-                    val msg = if (ping) {
-                        "Successfully connected to device!"
-                    } else {
-                        "Device access failed."
-                    }
-                    it.summary = msg
+                    it.summary = ping.getOrNull() ?: ping.exceptionOrNull()?.message
                 }
                 true
             }


### PR DESCRIPTION
- use last bonded device if multiple are available (instead of first)
- improve disconnect / connection loss cases
- check whether device has ble communication characteristics for autofill and inform user if not