### PR TITLE
bugfix of reversed app id query / cut-off app id components at 2 by default

### DIFF
--- a/app/src/main/java/de/mathfactory/mooltifill/SettingsActivity.kt
+++ b/app/src/main/java/de/mathfactory/mooltifill/SettingsActivity.kt
@@ -91,7 +91,7 @@ class SettingsActivity : AppCompatActivity() {
         private fun getPackageSubstitutionPolicy(context: Context): SubstitutionPolicy =
             PkgSubstitutionPolicies(
                 booleanSetting(context, "pkg_substitution_reverse", true),
-                intSetting(context, "pkg_substitution_max_components", 15))
+                intSetting(context, "pkg_substitution_max_components", 2))
 
         private fun <T> castChecked(block: () -> T): T? =
             try { block() } catch(e: ClassCastException) { null }

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -45,7 +45,7 @@
             app:key="pkg_substitution_max_components"
             app:title="Max. app id component count"
             app:summary="Cut-off app ids after specified amount of components"
-            app:defaultValue="15"
+            app:defaultValue="2"
             app:showSeekBarValue="true"
             app:seekBarIncrement="1"
             app:min="2"


### PR DESCRIPTION
bugfix of reversed app id query
cut-off app id components at 2 by default