### PR TITLE
autofill: Add Bromite to the autofill service whitelist

### DIFF
--- a/app/src/main/res/xml-v28/autofill_service.xml
+++ b/app/src/main/res/xml-v28/autofill_service.xml
@@ -66,4 +66,10 @@ Settings Activity. This is pointed to in the service's meta-data in the applicat
     <compatibility-package
             android:name="org.mozilla.firefox_beta"
             android:maxLongVersionCode="10000000000"/>
+    <compatibility-package
+            android:name="org.bromite.bromite"
+            android:maxLongVersionCode="10000000000"/>
+    <compatibility-package
+            android:name="org.bromite.chromium"
+            android:maxLongVersionCode="10000000000"/>
 </autofill-service>


### PR DESCRIPTION
This includes both versions of it, org.bromite.{bromite,chromium}. Partial fix to #22