### PR TITLE
mooltipass#21 Multiple Mini BLE Devices Support

### DIFF
--- a/app/src/androidTest/java/de/mathfactory/mooltifill/MooltipassInstrumentedTest.kt
+++ b/app/src/androidTest/java/de/mathfactory/mooltifill/MooltipassInstrumentedTest.kt
@@ -100,7 +100,7 @@ class MooltifillInstrumentedTest(private val useAwarenessService: Boolean) {
             assertNotNull(device)
             device!!
         } else {
-            val device = MooltipassScan().devices(appContext).firstOrNull()
+            val device = MooltipassScan.devices(appContext).firstOrNull()
             assertNotNull("Expected to find ble device", device)
             assert(device?.bondState == BluetoothDevice.BOND_BONDED) {"Device not bonded"}
             MooltipassDevice(device!!, 2).also { it.connect(CoroutineScope(Dispatchers.IO), appContext) }

--- a/app/src/androidTest/java/de/mathfactory/mooltifill/MooltipassInstrumentedTest.kt
+++ b/app/src/androidTest/java/de/mathfactory/mooltifill/MooltipassInstrumentedTest.kt
@@ -100,7 +100,7 @@ class MooltifillInstrumentedTest(private val useAwarenessService: Boolean) {
             assertNotNull(device)
             device!!
         } else {
-            val device = MooltipassScan().deviceFlow(appContext).firstOrNull()
+            val device = MooltipassScan().devices(appContext).firstOrNull()
             assertNotNull("Expected to find ble device", device)
             assert(device?.bondState == BluetoothDevice.BOND_BONDED) {"Device not bonded"}
             MooltipassDevice(device!!, 2).also { it.connect(CoroutineScope(Dispatchers.IO), appContext) }

--- a/app/src/main/java/de/mathfactory/mooltifill/BleMessageFactory.kt
+++ b/app/src/main/java/de/mathfactory/mooltifill/BleMessageFactory.kt
@@ -45,7 +45,7 @@ class BleMessageFactory(private val log: Boolean = true) : MessageFactory {
         }
         val len = getShort(data[0], HID_HEADER_SIZE + PACKET_LEN_OFFSET)
         val cmdInt = getShort(data[0], HID_HEADER_SIZE + PACKET_CMD_OFFSET)
-        val hidPayload = data.fold(ByteArray(0)) {a, chunk -> a + chunk.sliceArray(2 until 64)}
+        val hidPayload = data.fold(ByteArray(0)) {a, chunk -> a + chunk.sliceArray(2 until min(64, chunk.size))}
         if(len > hidPayload.size - PACKET_DATA_OFFSET) {
             if(log) Log.e("Mooltifill", "Not enough data for reported length: $len > ${hidPayload.size - PACKET_DATA_OFFSET}")
             return null

--- a/app/src/main/java/de/mathfactory/mooltifill/MooltifillActivity.kt
+++ b/app/src/main/java/de/mathfactory/mooltifill/MooltifillActivity.kt
@@ -138,7 +138,7 @@ class MooltifillActivity : Activity() {
             if(answer.cmd != MooltipassCommand.PING_BLE || !(ping.data contentEquals answer.data)) {
                 return Result.failure(Exception("Ping response invalid"))
             }
-            return Result.success("Successfully connected to device!")
+            return Result.success("Successfully connected to " + device.description())
         }
     }
 

--- a/app/src/main/java/de/mathfactory/mooltifill/SettingsActivity.kt
+++ b/app/src/main/java/de/mathfactory/mooltifill/SettingsActivity.kt
@@ -34,6 +34,7 @@ import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.edit
 import androidx.preference.*
 import kotlinx.coroutines.*
 import okhttp3.internal.publicsuffix.PublicSuffixDatabase
@@ -113,6 +114,9 @@ class SettingsActivity : AppCompatActivity() {
         fun isDebugEnabled(context: Context): Boolean = parsedIntSetting(context, "debug_level", 0) > 0
         fun isDebugVerbose(context: Context): Boolean = parsedIntSetting(context, "debug_level", 0) > 1
         fun isAwarenessEnabled(context: Context): Boolean = booleanSetting(context, "awareness", true)
+        fun isChosenDeviceAddress(context: Context, mac: String?, default: Boolean) = stringSetting(context, "chosen_device", null)
+                ?.let { it == mac } ?: default
+        fun setChosenDeviceAddress(context: Context, mac: String?) = if(mac == null) removeKey(context, "chosen_device") else putString(context, "chosen_device", mac)
 
         fun getSubstitutionPolicy(context: Context, isWebRq: Boolean): SubstitutionPolicy =
             if(isWebRq) { getUrlSubstitutionPolicy(context) } else { getPackageSubstitutionPolicy(context) }
@@ -127,6 +131,12 @@ class SettingsActivity : AppCompatActivity() {
 
         private fun <T> castChecked(block: () -> T): T? =
             try { block() } catch(e: ClassCastException) { null }
+
+        private fun putString(context: Context, key: String, value: String) =
+            PreferenceManager.getDefaultSharedPreferences(context).edit { putString(key, value) }
+
+        private fun removeKey(context: Context, key: String) =
+            PreferenceManager.getDefaultSharedPreferences(context).edit{ remove(key) }
 
         private fun booleanSetting(context: Context, key: String, default: Boolean) =
             castChecked { PreferenceManager.getDefaultSharedPreferences(context).getBoolean(key, default) } ?: default
@@ -201,6 +211,70 @@ class SettingsActivity : AppCompatActivity() {
 //        }
     }
 
+    class DeviceFragment : PreferenceFragmentCompat() {
+        override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+            setPreferencesFromResource(R.xml.device_preferences, rootKey)
+
+            findPreference<Preference>("test_ping")?.setOnPreferenceClickListener {
+                CoroutineScope(Dispatchers.Main).launch {
+                    it.summary = "Waiting for device access..."
+                    val ping = withContext(Dispatchers.IO) {
+                        MooltifillActivity.ping(requireContext())
+                    }
+                    it.summary = ping.getOrNull() ?: ping.exceptionOrNull()?.message
+                }
+                true
+            }
+
+            val rescan: () -> Unit = {
+                CoroutineScope(Dispatchers.Main).launch {
+                    findPreference<PreferenceCategory>("device_list")?.let { cat ->
+                        cat.removeAll()
+                        cat.addPreference(Preference(requireContext()).apply {
+                            title = "Performing scan..."
+                        })
+                        val devices = AwarenessService.deviceList().await()
+                        // get context after suspend. If we went out of view, return
+                        val ctx = context ?: return@let
+                        cat.removeAll()
+                        if (devices.isEmpty()) {
+                            cat.addPreference(Preference(ctx).apply {
+                                title =
+                                    "No device found. Please ensure bluetooth is enabled and the device is bonded in the Android system settings"
+                            })
+                        } else {
+                            devices.forEach { device ->
+                                cat.addPreference(Preference(ctx).also {
+                                    val chosen = isChosenDeviceAddress(ctx, device.address(), false)
+                                    if(chosen) it.setSummary(R.string.device_is_chosen)
+                                    it.title = device.description()
+                                    it.setOnPreferenceClickListener { p ->
+                                        Toast.makeText(
+                                            context,
+                                            "Using device " + device.description(),
+                                            Toast.LENGTH_SHORT
+                                        ).show()
+                                        // save preference
+                                        setChosenDeviceAddress(ctx, device.address())
+                                        for(pd in cat) {
+                                            pd.summary = null
+                                        }
+                                        p.setSummary(R.string.device_is_chosen)
+                                        // switch device
+                                        AwarenessService.setActive(device)
+                                        true
+                                    }
+                                })
+                            }
+                        }
+                    }
+                }
+            }
+
+            rescan()
+        }
+    }
+
     @FlowPreview
     @ExperimentalCoroutinesApi
     class SettingsFragment : PreferenceFragmentCompat() {
@@ -249,14 +323,12 @@ class SettingsActivity : AppCompatActivity() {
                 else AwarenessService.ensureService(requireContext(), null, true)
                 true
             }
-            findPreference<Preference>("test_ping")?.setOnPreferenceClickListener {
-                CoroutineScope(Dispatchers.Main).launch {
-                    it.summary = "Waiting for device access..."
-                    val ping = withContext(Dispatchers.IO) {
-                        MooltifillActivity.ping(requireContext())
-                    }
-                    it.summary = ping.getOrNull() ?: ping.exceptionOrNull()?.message
-                }
+            findPreference<Preference>("device_settings")?.setOnPreferenceClickListener {
+                parentFragmentManager.beginTransaction()
+                    .replace(R.id.settings, DeviceFragment())
+                    .setReorderingAllowed(true)
+                    .addToBackStack(null)
+                    .commit()
                 true
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,6 @@
 
     <!-- Preference Titles -->
     <string name="settings_header">Main Settings</string>
-    <string name="device_settings_header">Device Settings</string>
 
     <string name="awareness_title">Mooltipass Device Status</string>
     <string name="default_awareness_message">Disconnected</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,8 +5,10 @@
 
     <!-- Preference Titles -->
     <string name="settings_header">Main Settings</string>
+    <string name="device_settings_header">Device Settings</string>
 
     <string name="awareness_title">Mooltipass Device Status</string>
     <string name="default_awareness_message">Disconnected</string>
+    <string name="device_is_chosen">This device will be used</string>
 
 </resources>

--- a/app/src/main/res/xml/device_preferences.xml
+++ b/app/src/main/res/xml/device_preferences.xml
@@ -1,19 +1,26 @@
 <PreferenceScreen
         xmlns:app="http://schemas.android.com/apk/res-auto">
-
     <PreferenceCategory
-        app:title="@string/device_settings_header">
+            app:title="Device Settings">
         <Preference
-            app:key="test_ping"
-            app:title="Test Mooltipass Device Connection"
-            app:summary="Please enable Bluetooth and be sure to have the ble device paired before testing the connection." />
+                app:key="open_bt_settings"
+                app:title="Configure bonded device"
+                app:summary="Click here to go to the android settings to pair a device. Paired devices will then be shown in the list below. If you have multiple devices, you can select which should be used, otherwise the device that connects first is used." />
     </PreferenceCategory>
 
     <PreferenceCategory
             app:title="Device List"
             app:key="device_list">
         <Preference
-            app:title="Press &quot;Rescan bonded devices&quot; to start scan" />
+                app:title="Retrieving bonded devices list..." />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+            app:title="Functionality Test">
+        <Preference
+                app:key="test_ping"
+                app:title="Test Mooltipass Device Connection"
+                app:summary="Please enable Bluetooth and be sure to have the ble device paired before testing the connection." />
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/device_preferences.xml
+++ b/app/src/main/res/xml/device_preferences.xml
@@ -1,0 +1,19 @@
+<PreferenceScreen
+        xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <PreferenceCategory
+        app:title="@string/device_settings_header">
+        <Preference
+            app:key="test_ping"
+            app:title="Test Mooltipass Device Connection"
+            app:summary="Please enable Bluetooth and be sure to have the ble device paired before testing the connection." />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+            app:title="Device List"
+            app:key="device_list">
+        <Preference
+            app:title="Press &quot;Rescan bonded devices&quot; to start scan" />
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -16,9 +16,9 @@
             app:summaryOff="Do not track connection state of the mooltipass device"
             app:defaultValue="true" />
         <Preference
-            app:key="test_ping"
-            app:title="Test Mooltipass Device Connection"
-            app:summary="Please enable Bluetooth and be sure to have the ble device paired before testing the connection." />
+            app:key="device_settings"
+            app:title="Device Settings"
+            app:summary="Open the device settings" />
         <ListPreference
             app:key="debug_level"
             app:title="Debug Output to logcat"

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -18,7 +18,7 @@
         <Preference
             app:key="device_settings"
             app:title="Device Settings"
-            app:summary="Open the device settings" />
+            app:summary="Configure mooltipass devices" />
         <ListPreference
             app:key="debug_level"
             app:title="Debug Output to logcat"


### PR DESCRIPTION
Implementation of #21:
- Instead of trying to connect to the last bonded device, initiate connection to all known (bonded) devices
- Use the first device that successfully connects
- in the device Settings, there is now a submenu to view the paired devices by name and address
- Also, the user can choose to a specific device in the list he wants to use