### PR TITLE
WIP: Fix crash when starting `AwarenessService`

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" android:minSdkVersion="34"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" android:minSdkVersion="34"/>
 
     <uses-feature
             android:name="android.hardware.bluetooth_le"
@@ -37,7 +38,7 @@
             android:name=".AwarenessService"
             android:enabled="true"
             android:exported="false"
-            android:foregroundServiceType="dataSync">
+            android:foregroundServiceType="connectedDevice">
         </service>
 
         <activity android:name=".MooltifillActivity"

--- a/app/src/main/java/de/mathfactory/mooltifill/AwarenessService.kt
+++ b/app/src/main/java/de/mathfactory/mooltifill/AwarenessService.kt
@@ -8,6 +8,8 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.ServiceInfo
+import android.os.Build
 import android.os.IBinder
 import android.util.Log
 import androidx.core.app.NotificationCompat
@@ -251,7 +253,14 @@ class AwarenessService : Service() {
             ?: getString(R.string.default_awareness_message)
         val notification = createNotification(this, msg)
 
-        startForeground(ONGOING_NOTIFICATION_ID, notification)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(ONGOING_NOTIFICATION_ID, notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
+            )
+        } else {
+            startForeground(ONGOING_NOTIFICATION_ID, notification)
+        }
+
         serviceStarted.complete(Unit)
         scheduleSendTime()
         return START_STICKY

--- a/app/src/main/java/de/mathfactory/mooltifill/BootReceiver.kt
+++ b/app/src/main/java/de/mathfactory/mooltifill/BootReceiver.kt
@@ -3,7 +3,6 @@ package de.mathfactory.mooltifill
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 
 
 class BootReceiver : BroadcastReceiver() {


### PR DESCRIPTION
Issue: https://github.com/mooltipass/android_companion/issues/44

**Cause**:
When targeting SDK level 35, `dataSync` service is no longer allowed to be started via `BOOT_COMPLETED` receiver: https://developer.android.com/about/versions/15/behavior-changes-15#fgs-boot-completed
Also, it has a limit of maximumly 6 hours running continuously during a 24-hr period: https://developer.android.com/about/versions/15/behavior-changes-15#datasync-timeout

**Measure**:
Change `AwarenessService` from `dataSync` to `connectedDevice` foreground service type, which doesn't have above limitation.